### PR TITLE
[♻️ Refactor/331] useQueryParamState 훅 불필요한 props 삭제

### DIFF
--- a/src/shared/hooks/useQueryParamState.ts
+++ b/src/shared/hooks/useQueryParamState.ts
@@ -7,7 +7,6 @@ type ParseOption<T> = T extends string ? { parse?: (v: string) => T } : { parse:
 
 type UseQueryParamStateOptions<T> = {
   defaultValue: T;
-  serialize?: (value: T) => string;
   replace?: boolean;
   scroll?: boolean;
   removeParam?: (value: T) => boolean;
@@ -25,7 +24,6 @@ type UseQueryParamStateOptions<T> = {
  *
  * @param key - 쿼리 키
  * @param parse - URL string을 원하는 타입의 상태값으로 변환하는 함수
- * @param serialize - 상태값 → URL string으로 변환하는 함수
  * @param replace - history 관리 방식 (true: replace, false: push)
  * @param scroll - 라우팅 시 스크롤 이동 여부 (기본값: false)
  * @param removeParam - 특정 조건일 때 쿼리 파라미터를 제거할 지 여부
@@ -44,7 +42,6 @@ const useQueryParamState = <T = string>(
   {
     defaultValue,
     parse = (v) => v as T,
-    serialize = String,
     replace = true,
     scroll = false,
     removeParam,
@@ -74,7 +71,7 @@ const useQueryParamState = <T = string>(
       if (removeParam?.(nextValue)) {
         params.delete(key);
       } else {
-        params.set(key, serialize(nextValue));
+        params.set(key, String(nextValue));
       }
 
       const query = params.toString();
@@ -86,7 +83,7 @@ const useQueryParamState = <T = string>(
         router.push(url, { scroll });
       }
     },
-    [key, pathname, replace, router, scroll, serialize, removeParam]
+    [key, pathname, replace, router, scroll, removeParam]
   );
 
   return [value, setValue];


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈 제목과 동일하게 작성해 주세요. -->
<!-- ex) [타입/이슈 번호] 이슈 제목 -->
<!-- ex) [✨ Feature/1] 로그인 페이지 UI 구현 -->

## ✅ PR 체크리스트

### 1. 코드 & 기능

- [x] 변수/함수 이름 이해 가능한지
- [x] 기능 정상 동작 & 콘솔 에러 없음

## 2. UI

- [X] UI 동작 및 레이아웃 확인

## 3. 컨벤션

- [x] 팀 컨벤션에 맞게 함수 이름을 정의했는지

## 🔗 이슈 번호

<!-- PR과 연관된 이슈 번호를 작성해 주세요. ex) #1 -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->

- close #331

## ✨ 작업한 내용

<!-- 작업한 내용을 작성해 주세요 .-->
<!-- 프리뷰 링크로 확인 어려운 컴포넌트라면 스크린샷을 추가해주세요.-->

- useQueryParamsState에 사용하지 않는 serialize 옵션을 제거했습니다.
- 만들 당시에는 객체를 넘기는 케이스가 있을 것 같아서 넣어두었는데, 실제로는 String()으로 형변환이 가능한 값들만 넘어와서 제거했습니다!

## 💁 리뷰 요청 / 코멘트

<!-- 코드리뷰가 필요한 부분이 있다면 작성해 주세요. -->

## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->
