### PR TITLE
[🐛 Bug/347] 페이지 이동 후 오버레이 컴포넌트가 유지되는 문제 해결

### DIFF
--- a/src/shared/components/overlay/root/OverlayRoot.tsx
+++ b/src/shared/components/overlay/root/OverlayRoot.tsx
@@ -21,23 +21,18 @@ export default function OverlayRoot() {
   const pathname = usePathname();
   const params = useParams();
   const isMounted = useRef(false);
-  const prevPathname = useRef(pathname);
-  const prevParams = useRef(params);
 
   useEffect(() => {
-    // 전체 경로를 문자열로 만들어 비교
-    const currentFullPath = `${pathname}${JSON.stringify(params)}`;
-    const prevFullPath = `${prevPathname.current}${JSON.stringify(prevParams.current)}`;
-
-    if (isMounted.current && currentFullPath !== prevFullPath) {
-      // 경로나 파라미터가 실제로 변경되었을 때만 오버레이 닫기
+    if (isMounted.current) {
+      // 경로나 파라미터가 변경될 때마다 무조건 모든 overlay 초기화
       overlayStore.clear();
-    } else {
-      isMounted.current = true;
     }
+    isMounted.current = true;
 
-    prevPathname.current = pathname;
-    prevParams.current = params;
+    // 컴포넌트 언마운트 시에도 정리
+    return () => {
+      overlayStore.clear();
+    };
   }, [pathname, params]);
 
   const isOpenOverlay = overlays.length > 0;


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈 제목과 동일하게 작성해 주세요. -->
<!-- ex) [타입/이슈 번호] 이슈 제목 -->
<!-- ex) [✨ Feature/1] 로그인 페이지 UI 구현 -->

## ✅ PR 체크리스트

### 1. 코드 & 기능

- [X] 변수/함수 이름 이해 가능한지
- [X] 기능 정상 동작 & 콘솔 에러 없음

## 2. UI

- [X] UI 동작 및 레이아웃 확인

## 3. 컨벤션

- [X] 팀 컨벤션에 맞게 함수 이름을 정의했는지

## 🔗 이슈 번호

<!-- PR과 연관된 이슈 번호를 작성해 주세요. ex) #1 -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->

- close #347 

## ✨ 작업한 내용

<!-- 작업한 내용을 작성해 주세요 .-->
<!-- 프리뷰 링크로 확인 어려운 컴포넌트라면 스크린샷을 추가해주세요.-->

- 페이지 이동 시 오버레이 자동 닫기 기능을 추가했습니다!
  - `OverlayRoot`에서 `usePathname` 훅을 사용하여 경로 변경을 감지합니다
  - pathname이 변경되면 `overlayStore.clear()`를 호출하여 모든 오버레이를 자동으로 닫습니다
  - 페이지 전환 시 이전 페이지의 Dialog, BottomSheet 등이 남아있는 문제를 해결했습니다

## 💁 리뷰 요청 / 코멘트

<!-- 코드리뷰가 필요한 부분이 있다면 작성해 주세요. -->

- 수정 사항이 있다면 말씀해주세요!

## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->

- Next.js의 `usePathname` 훅을 사용했습니다
- `overlayStore.clear()`는 모든 오버레이를 한 번에 닫는 기존 메서드를 활용했습니다
- 스크롤 락 및 ESC 키 핸들러는 `isOpenOverlay` 상태에 따라 자동으로 정리됩니다
