### PR TITLE
[⚠️ Fix/355] 알림 모달 수정

### DIFF
--- a/src/features/notification/components/NotificationButton.tsx
+++ b/src/features/notification/components/NotificationButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRef, useState } from 'react';
+import { toast } from 'react-toastify';
 import Icons from '@/assets/icons';
 import { useDeleteNotificationMutation } from '@/features/notification/mutations/useDeleteNotificationMutation';
 import { useNotificationsQuery } from '@/features/notification/queries/useNotificationsQuery';
@@ -32,16 +33,19 @@ export default function NotificationButton() {
     );
   };
 
+  const handleClick = () => {
+    if (!hasNotifications) {
+      toast.info('새로운 알림이 없습니다.');
+      return;
+    }
+    setIsModalOpen((prev) => !prev);
+  };
+
   return (
     <div
       ref={notificationRef}
       className='relative box-content w-24 pr-20 after:absolute after:top-1/2 after:right-0 after:block after:h-14 after:w-1 after:-translate-y-1/2 after:bg-gray-100'>
-      <button
-        type='button'
-        aria-label='알림'
-        disabled={!hasNotifications}
-        data-disabled={!hasNotifications}
-        onClick={() => setIsModalOpen((prev) => !prev)}>
+      <button type='button' aria-label='알림' className='cursor-pointer' onClick={handleClick}>
         {hasNotifications ? (
           <Icons.Alert
             className={cn('h-24 w-24 text-gray-600', isModalOpen ? 'text-primary-500' : '')}

--- a/src/features/notification/components/NotificationButton.tsx
+++ b/src/features/notification/components/NotificationButton.tsx
@@ -23,6 +23,9 @@ export default function NotificationButton() {
   const hasNotifications = notifications.length > 0;
 
   const handleDeleteOne = (id: number) => {
+    if (notifications.length === 1) {
+      setIsModalOpen(false);
+    }
     deleteNotification(id);
   };
 

--- a/src/features/notification/components/NotificationButton.tsx
+++ b/src/features/notification/components/NotificationButton.tsx
@@ -34,6 +34,7 @@ export default function NotificationButton() {
     await Promise.allSettled(
       notifications.map((notification) => deleteNotificationAsync(notification.id))
     );
+    toast.success('모든 알림을 성공적으로 삭제했습니다.');
   };
 
   const handleClick = () => {

--- a/src/features/notification/components/NotificationButton.tsx
+++ b/src/features/notification/components/NotificationButton.tsx
@@ -49,7 +49,7 @@ export default function NotificationButton() {
     <div
       ref={notificationRef}
       className='relative box-content w-24 pr-20 after:absolute after:top-1/2 after:right-0 after:block after:h-14 after:w-1 after:-translate-y-1/2 after:bg-gray-100'>
-      <button type='button' aria-label='알림' className='cursor-pointer' onClick={handleClick}>
+      <button type='button' aria-label='알림' onClick={handleClick}>
         {hasNotifications ? (
           <Icons.Alert
             className={cn('h-24 w-24 text-gray-600', isModalOpen ? 'text-primary-500' : '')}


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈 제목과 동일하게 작성해 주세요. -->
<!-- ex) [타입/이슈 번호] 이슈 제목 -->
<!-- ex) [✨ Feature/1] 로그인 페이지 UI 구현 -->

## ✅ PR 체크리스트

### 1. 코드 & 기능

- [x] 변수/함수 이름 이해 가능한지
- [x] 기능 정상 동작 & 콘솔 에러 없음

## 2. UI

- [x] UI 동작 및 레이아웃 확인

## 3. 컨벤션

- [x] 팀 컨벤션에 맞게 함수 이름을 정의했는지

## 🔗 이슈 번호

<!-- PR과 연관된 이슈 번호를 작성해 주세요. ex) #1 -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->

- close #355 

## ✨ 작업한 내용
1. 알림 전체 삭제 시 삭제 완료 토스트 메세지 추가
2. 개별 삭제로 알림 1개 -> 0개 될 때 모달을 먼저 닫고 삭제 로직 진행 (사용자가 '알림 0개' 문구 볼 일 없음)
3. 알림이 0개 일 때도 아이콘 클릭은 가능하게. 다만 토스트로 '새로운 알림이 없습니다.' 띄움

| 1️⃣ 전체 삭제 토스트 | 2️⃣ 개별 삭제 UX 개선 | 3️⃣ 빈 알림 클릭 시 |
| :---: | :---: | :---: |
| <img src="https://github.com/user-attachments/assets/79c540ad-17a1-4de9-82e1-7ee7d0fe4929" width="240" /> | <img src="https://github.com/user-attachments/assets/a3a81157-a721-4d66-b410-2a2d0d533f61" width="240" /> | <img src="https://github.com/user-attachments/assets/00c196a5-761a-4e7f-9112-b714c4915980" width="240" /> |

## 💁 리뷰 요청 / 코멘트

<!-- 코드리뷰가 필요한 부분이 있다면 작성해 주세요. -->

## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->
