### PR TITLE
[⚠️ Fix/376] main 모든체험 수정 main 모든 체험 2페이지에서 필터 누를 때 에러

### DIFF
--- a/src/features/main/components/all-activity/AllActivity.tsx
+++ b/src/features/main/components/all-activity/AllActivity.tsx
@@ -35,6 +35,7 @@ export default function AllActivity({
     activities,
     totalCount,
     isPending,
+    updateFilters,
   } = useActivityFilters();
 
   // 상위로 activities 갯수 보내기
@@ -101,8 +102,10 @@ export default function AllActivity({
                 key={item.value}
                 isActive={isActive}
                 onClick={() => {
-                  setCurrentPage(1);
-                  setCategory(isActive ? undefined : item.value);
+                  updateFilters({
+                    page: 1,
+                    category: isActive ? undefined : item.value,
+                  });
                 }}>
                 <span>{item.label}</span>
               </FilterButton>

--- a/src/features/main/hooks/useActivityFilters.ts
+++ b/src/features/main/hooks/useActivityFilters.ts
@@ -85,7 +85,7 @@ export const useActivityFilters = () => {
       }
     });
 
-    router.push(`?${params.toString()}`);
+    router.push(`?${params.toString()}`, { scroll: false });
   };
 
   return {


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈 제목과 동일하게 작성해 주세요. -->
<!-- ex) [타입/이슈 번호] 이슈 제목 -->
<!-- ex) [✨ Feature/1] 로그인 페이지 UI 구현 -->

## ✅ PR 체크리스트

### 1. 코드 & 기능

- [x] 변수/함수 이름 이해 가능한지
- [x] 기능 정상 동작 & 콘솔 에러 없음

## 2. UI

- [x] UI 동작 및 레이아웃 확인

## 3. 컨벤션

- [x] 팀 컨벤션에 맞게 함수 이름을 정의했는지

## 🔗 이슈 번호

<!-- PR과 연관된 이슈 번호를 작성해 주세요. ex) #1 -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->

- close #376

## ✨ 작업한 내용

<!-- 작업한 내용을 작성해 주세요 .-->
<!-- 프리뷰 링크로 확인 어려운 컴포넌트라면 스크린샷을 추가해주세요.-->
main 모든 체험 2페이지에서 필터 누를 때 내용이 있음에도 없다고 나오는 문제가 발생하여서
필터를 누를 때는 1페이지로 이동하도록 수정했습니다.

## 💁 리뷰 요청 / 코멘트

<!-- 코드리뷰가 필요한 부분이 있다면 작성해 주세요. -->

## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->
