### PR TITLE
[⚠️ Fix/381] 체험 상세 페이지에서 오늘 날짜 선택 시 이미 지난 시간대가 표시되는 문제 수정

### DIFF
--- a/src/features/activity-detail/components/reservation/content/ActivityReservationDateTimeSection.tsx
+++ b/src/features/activity-detail/components/reservation/content/ActivityReservationDateTimeSection.tsx
@@ -81,8 +81,9 @@ export default function ActivityReservationDateTimeSection({
   onMonthChange,
   isBottomSheet = false,
 }: ActivityReservationDateTimeSectionProps) {
-  const today = startOfDay(new Date());
-  const availableDates = getAvailableDates(schedules, today);
+  const now = new Date();
+  const today = startOfDay(now);
+  const availableDates = getAvailableDates(schedules, today, now);
 
   // 선택된 날짜의 시간 목록
   const scheduleTimes = selectedDate
@@ -108,7 +109,7 @@ export default function ActivityReservationDateTimeSection({
         <ActivityReservationContentTitle>예약 가능한 시간</ActivityReservationContentTitle>
         <ActivityReservationTimeSlotSelector
           selectedDate={selectedDate}
-          availableTimes={filterTimesByNow(scheduleTimes, selectedDate)}
+          availableTimes={filterTimesByNow(scheduleTimes, selectedDate, now)}
           selectedScheduleId={selectedScheduleId}
           onSelectSchedule={onScheduleSelect}
         />

--- a/src/features/activity-detail/utils/reservationDateUtils.ts
+++ b/src/features/activity-detail/utils/reservationDateUtils.ts
@@ -53,17 +53,18 @@ export const getSchedulesByDate = (schedules: ScheduleResponseDto[]) => {
  *
  * @param times - 시간대 배열
  * @param selectedDate - 선택된 날짜
+ * @param now - 현재 시간 (상위 컴포넌트에서 전달)
  * @returns 필터링된 시간대 배열
  */
 export const filterTimesByNow = (
   times: Array<{ id: number; startTime: string; endTime: string }>,
-  selectedDate: Date | undefined
+  selectedDate: Date | undefined,
+  now: Date
 ): Array<{ id: number; startTime: string; endTime: string }> => {
   if (!selectedDate) {
     return times;
   }
 
-  const now = new Date();
   const today = startOfDay(now);
   const selectedDay = startOfDay(selectedDate);
 
@@ -96,9 +97,14 @@ export const filterTimesByNow = (
  *
  * @param schedules - 스케줄 배열
  * @param today - 기준 날짜 (일반적으로 오늘 날짜)
+ * @param now - 현재 시간 (상위 컴포넌트에서 전달)
  * @returns 예약 가능한 날짜 배열 (기준 날짜 포함, 이후 날짜만)
  */
-export const getAvailableDates = (schedules: ScheduleResponseDto[], today: Date): Date[] => {
+export const getAvailableDates = (
+  schedules: ScheduleResponseDto[],
+  today: Date,
+  now: Date
+): Date[] => {
   return schedules
     .filter((schedule) => {
       const scheduleDate = new Date(schedule.date);
@@ -109,7 +115,7 @@ export const getAvailableDates = (schedules: ScheduleResponseDto[], today: Date)
       }
 
       // filterTimesByNow를 사용하여 현재 시간 이후 시간대 확인
-      const availableTimes = filterTimesByNow(schedule.times, scheduleDate);
+      const availableTimes = filterTimesByNow(schedule.times, scheduleDate, now);
 
       return availableTimes.length > 0;
     })


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈 제목과 동일하게 작성해 주세요. -->
<!-- ex) [타입/이슈 번호] 이슈 제목 -->
<!-- ex) [✨ Feature/1] 로그인 페이지 UI 구현 -->

## ✅ PR 체크리스트

### 1. 코드 & 기능

- [X] 변수/함수 이름 이해 가능한지
- [X] 기능 정상 동작 & 콘솔 에러 없음

## 2. UI

- [X] UI 동작 및 레이아웃 확인

## 3. 컨벤션

- [X] 팀 컨벤션에 맞게 함수 이름을 정의했는지

## 🔗 이슈 번호

<!-- PR과 연관된 이슈 번호를 작성해 주세요. ex) #1 -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->

- close #381 

## ✨ 작업한 내용

<!-- 작업한 내용을 작성해 주세요 .-->
<!-- 프리뷰 링크로 확인 어려운 컴포넌트라면 스크린샷을 추가해주세요.-->

- 체험 상세 페이지의 예약에서 오늘 날짜의 현재 시간 이후의 시간대만 표시되도록 수정

## 💁 리뷰 요청 / 코멘트

<!-- 코드리뷰가 필요한 부분이 있다면 작성해 주세요. -->

- 현재 시각과 정확히 같은 시간의 예약을 허용하는 것이 맞는지 검토가 필요합니다.
- 만약 여유 시간(예: 30분 전까지만 예약 가능)이 필요하다면 추가 로직 필요할 수 있습니다.

## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->

- `filterTimesByNow` 함수는 두 곳에서 사용됩니다.
  - `ActivityReservationDateTimeSection`에서 시간대 목록 필터링
  - `getAvailableDates`에서 오늘 날짜의 예약 가능 여부 판단
