### PR TITLE
🐛 Fix: 리뷰 내용 101글자 작성 시 버튼 비활성화 조건 추가

### DIFF
--- a/src/features/mypage/reservation-list/components/ReviewModal.tsx
+++ b/src/features/mypage/reservation-list/components/ReviewModal.tsx
@@ -24,6 +24,8 @@ interface ReviewModalProps {
   headCount: number;
 }
 
+const REVIEW_MAX_LENGTH = 100;
+
 /**
  * @description
  * - 예약 완료된 체험에 대해 후기를 작성하는 모달 컴포넌트입니다.
@@ -121,13 +123,13 @@ export default function ReviewModal({
           placeholder='체험에서 느낀 경험을 자유롭게 남겨주세요.'
           value={content}
           onChange={(e) => setContent(e.target.value)}
-          maxLength={100}
+          maxLength={REVIEW_MAX_LENGTH}
         />
         <Button
           type='submit'
           size='lg'
           isLoading={isPending}
-          disabled={!content.trim() || content.length > 100 || rating === 0}
+          disabled={!content.trim() || content.length > REVIEW_MAX_LENGTH || rating === 0}
           full
           onClick={handleSubmit}>
           작성하기


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈 제목과 동일하게 작성해 주세요. -->
<!-- ex) [타입/이슈 번호] 이슈 제목 -->
<!-- ex) [✨ Feature/1] 로그인 페이지 UI 구현 -->

## ✅ PR 체크리스트

### 1. 코드 & 기능

- [x] 변수/함수 이름 이해 가능한지
- [x] 기능 정상 동작 & 콘솔 에러 없음

## 2. UI

- [x] UI 동작 및 레이아웃 확인

## 3. 컨벤션

- [x] 팀 컨벤션에 맞게 함수 이름을 정의했는지

## 🔗 이슈 번호
- close #396 

## ✨ 작업한 내용
- 리뷰 등록 버튼 비활성화 조건이 `disabled={!content.trim() || rating === 0}` 뿐이라 100글자 이상 작성해도 등록 버튼이 활성화 되는 문제 해결
- 조건을 하나 더 추가했습니다. (`disabled={!content.trim() || content.length > 100 || rating === 0}`)

![화면 기록 2026-01-22 15 28 26](https://github.com/user-attachments/assets/c39ed5e1-2877-4bbc-a071-d3f748de0c69)


## 💁 리뷰 요청 / 코멘트

<!-- 코드리뷰가 필요한 부분이 있다면 작성해 주세요. -->

## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->
