### PR TITLE
[⚠️ Fix/419] 다음 우편번호 서비스 도메인 변경

### DIFF
--- a/src/features/activity-form/common/components/address-section/AddressSection.tsx
+++ b/src/features/activity-form/common/components/address-section/AddressSection.tsx
@@ -5,7 +5,7 @@ import { useAddressForm } from '@/features/activity-form/common/hooks/useAddress
 import Input from '@/shared/components/input/Input';
 
 /** 다음 주소 검색 API 스크립트 URL */
-const SCRIPT_URL = '//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
+const SCRIPT_URL = '//t1.kakaocdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
 
 interface AddressSectionProps {
   /**


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈 제목과 동일하게 작성해 주세요. -->
<!-- ex) [타입/이슈 번호] 이슈 제목 -->
<!-- ex) [✨ Feature/1] 로그인 페이지 UI 구현 -->

## ✅ PR 체크리스트

### 1. 코드 & 기능

- [x] 변수/함수 이름 이해 가능한지
- [x] 기능 정상 동작 & 콘솔 에러 없음

## 2. UI

- [x] UI 동작 및 레이아웃 확인

## 3. 컨벤션

- [x] 팀 컨벤션에 맞게 함수 이름을 정의했는지

## 🔗 이슈 번호

<!-- PR과 연관된 이슈 번호를 작성해 주세요. ex) #1 -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->

- close #419

## ✨ 작업한 내용

<!-- 작업한 내용을 작성해 주세요 .-->
<!-- 프리뷰 링크로 확인 어려운 컴포넌트라면 스크린샷을 추가해주세요.-->

https://github.com/daumPostcode/QnA/issues/1498
https://github.com/kmsbernard/react-daum-postcode/issues/77

<img width="431" height="217" alt="image" src="https://github.com/user-attachments/assets/dc291460-30bb-4c0c-bfd8-eedd466971e5" />

체험 등록/수정 폼에서 사용하고 있는 다음 우편번호 검색 서비스 도메인이 변경되어서 수정했습니다.
현재 사용하고 있는 패키지(react-daum-postcode)도 업데이트 되면 바로 버전 업데이트 해서 PR 올리겠습니다!

## 💁 리뷰 요청 / 코멘트

<!-- 코드리뷰가 필요한 부분이 있다면 작성해 주세요. -->

## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->
