### PR TITLE
[♻️ Refactor/434] 이미지 확대 모달 이전/다음 핸들러 단일 함수로 리팩토링

### DIFF
--- a/src/features/activity-detail/components/image/ActivityImageModal.tsx
+++ b/src/features/activity-detail/components/image/ActivityImageModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Icons from '@/assets/icons';
 import { LAYER } from '@/shared/components/overlay/constants/layer';
 import Backdrop from '@/shared/components/overlay/primitives/backdrop/Backdrop';
@@ -53,26 +53,26 @@ export default function ActivityImageModal({
 
   const currentImage = images[currentIndex];
 
-  const handlePrev = useCallback(() => {
+  const handlePrev = () => {
     setCurrentIndex((prev) => (prev - 1 + images.length) % images.length);
-  }, [images.length]);
+  };
 
-  const handleNext = useCallback(() => {
+  const handleNext = () => {
     setCurrentIndex((prev) => (prev + 1) % images.length);
-  }, [images.length]);
+  };
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'ArrowLeft') {
-        handlePrev();
+        setCurrentIndex((prev) => (prev - 1 + images.length) % images.length);
       }
       if (e.key === 'ArrowRight') {
-        handleNext();
+        setCurrentIndex((prev) => (prev + 1) % images.length);
       }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [handlePrev, handleNext]);
+  }, [images.length]);
 
   return (
     <OverlayPortal>

--- a/src/features/activity-detail/components/image/ActivityImageModal.tsx
+++ b/src/features/activity-detail/components/image/ActivityImageModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Icons from '@/assets/icons';
 import { LAYER } from '@/shared/components/overlay/constants/layer';
 import Backdrop from '@/shared/components/overlay/primitives/backdrop/Backdrop';
@@ -53,26 +53,29 @@ export default function ActivityImageModal({
 
   const currentImage = images[currentIndex];
 
-  const handlePrev = () => {
-    setCurrentIndex((prev) => (prev - 1 + images.length) % images.length);
-  };
-
-  const handleNext = () => {
-    setCurrentIndex((prev) => (prev + 1) % images.length);
-  };
+  const moveIndex = useCallback(
+    (direction: 'prev' | 'next') => {
+      setCurrentIndex((prev) =>
+        direction === 'prev'
+          ? (prev - 1 + images.length) % images.length
+          : (prev + 1) % images.length
+      );
+    },
+    [images.length]
+  );
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'ArrowLeft') {
-        setCurrentIndex((prev) => (prev - 1 + images.length) % images.length);
+        moveIndex('prev');
       }
       if (e.key === 'ArrowRight') {
-        setCurrentIndex((prev) => (prev + 1) % images.length);
+        moveIndex('next');
       }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [images.length]);
+  }, [moveIndex]);
 
   return (
     <OverlayPortal>
@@ -105,7 +108,7 @@ export default function ActivityImageModal({
               aria-label='이전 이미지'
               onClick={(e) => {
                 e.stopPropagation();
-                handlePrev();
+                moveIndex('prev');
               }}
               className='absolute top-1/2 -left-32 h-32 w-32 text-gray-100'>
               <Icons.ChevronLeft aria-hidden='true' focusable='false' />
@@ -114,7 +117,7 @@ export default function ActivityImageModal({
               aria-label='다음 이미지'
               onClick={(e) => {
                 e.stopPropagation();
-                handleNext();
+                moveIndex('next');
               }}
               className='absolute top-1/2 -right-32 h-32 w-32 text-gray-100'>
               <Icons.ChevronRight aria-hidden='true' focusable='false' />


### PR DESCRIPTION
## ✅ PR 체크리스트

### 1. 코드 & 기능

- [x] 변수/함수 이름 이해 가능한지
- [x] 기능 정상 동작 & 콘솔 에러 없음

## 2. UI

- [x] UI 동작 및 레이아웃 확인

## 3. 컨벤션

- [x] 팀 컨벤션에 맞게 함수 이름을 정의했는지

## 🔗 이슈 번호

- close #434

## ✨ 작업한 내용

이미지 확대 모달의 키보드 이벤트 핸들러에서 불필요한 useCallback을 제거했습니다.
images.length가 모달이 열린 동안 변하지 않아 메모이제이션 이점이 없고,
자식 컴포넌트에 props로 전달하지 않아 리렌더링 방지 효과도 없기 때문입니다.
키보드 이벤트 로직은 useEffect 내부로 인라인 처리하여 의존성 배열을 단순화했습니다.

## 💁 리뷰 요청 / 코멘트

## 💡 참고사항