### PR TITLE
[🐛 Bug/450] 예약 위젯 캘린더 마지막 날짜가 그리드 밖으로 overflow

### DIFF
--- a/src/features/activity-detail/components/reservation/content/ActivityReservationDatePicker.tsx
+++ b/src/features/activity-detail/components/reservation/content/ActivityReservationDatePicker.tsx
@@ -80,6 +80,7 @@ export default function ActivityReservationDatePicker({
   return (
     <DayPicker
       className='custom-day-picker reservation-day-picker h-auto w-full'
+      fixedWeeks
       mode='single'
       locale={ko}
       selected={selectedDate}

--- a/src/features/activity-detail/components/reservation/content/ActivityReservationDatePicker.tsx
+++ b/src/features/activity-detail/components/reservation/content/ActivityReservationDatePicker.tsx
@@ -79,7 +79,7 @@ export default function ActivityReservationDatePicker({
 
   return (
     <DayPicker
-      className='custom-day-picker reservation-day-picker h-300 w-full'
+      className='custom-day-picker reservation-day-picker h-auto w-full'
       mode='single'
       locale={ko}
       selected={selectedDate}

--- a/src/features/activity-detail/components/reservation/content/ActivityReservationDatePicker.tsx
+++ b/src/features/activity-detail/components/reservation/content/ActivityReservationDatePicker.tsx
@@ -79,7 +79,7 @@ export default function ActivityReservationDatePicker({
 
   return (
     <DayPicker
-      className='custom-day-picker reservation-day-picker h-auto w-full'
+      className='custom-day-picker reservation-day-picker w-full'
       fixedWeeks
       mode='single'
       locale={ko}


### PR DESCRIPTION
## ✅ PR 체크리스트

### 1. 코드 & 기능

- [x] 변수/함수 이름 이해 가능한지
- [x] 기능 정상 동작 & 콘솔 에러 없음

## 2. UI

- [x] UI 동작 및 레이아웃 확인

## 3. 컨벤션

- [x] 팀 컨벤션에 맞게 함수 이름을 정의했는지

## 🔗 이슈 번호

- close #450

## ✨ 작업한 내용

예약 위젯 캘린더에서 31일처럼 마지막 날짜가 6번째 행에 단독으로 배치될 때 고정 높이(`h-300`)를 초과해 그리드 밖으로 밀려나는 문제 수정

- `ActivityReservationDatePicker.tsx`: `h-300` → `h-auto`로 변경하여 달력 행 수에 따라 높이가 가변적으로 조정되도록 수정

| 수정 전 | 수정 후 |
|---------|---------|
| 31일이 `예약 가능한 시간` 레이블과 겹침 | 31일이 캘린더 그리드 내 정상 배치 |

## 💁 리뷰 요청 / 코멘트

## 💡 참고사항