### PR TITLE
[🐛 Bug/453] 예약현황 캘린더 6행 고정 및 스켈레톤 높이 수정

### DIFF
--- a/src/features/mypage/reservation-status/components/skeleton/ReservationCalendarSkeleton.tsx
+++ b/src/features/mypage/reservation-status/components/skeleton/ReservationCalendarSkeleton.tsx
@@ -21,6 +21,6 @@ import Skeleton from '@/shared/components/skeleton/Skeleton';
  */
 export default function ReservationCalendarSkeleton() {
   return (
-    <Skeleton className='-mx-24 h-605 w-screen sm:mx-auto sm:h-770 sm:w-full sm:rounded-24 lg:h-776' />
+    <Skeleton className='-mx-24 h-709 w-screen sm:mx-auto sm:h-888 sm:w-full sm:rounded-24 lg:h-888' />
   );
 }

--- a/src/features/mypage/reservation-status/utils/calendarUtils.ts
+++ b/src/features/mypage/reservation-status/utils/calendarUtils.ts
@@ -80,11 +80,13 @@ export const canNavigateToNextMonth = (currentMonth: Date, maxDate: Date): boole
  * @param startDate - 캘린더에 표시될 시작 날짜
  * @returns 달력에 표시할 날짜 배열 (항상 42개)
  */
+const TOTAL_CALENDAR_DAYS = 42;
+
 export const generateCalendarDays = (startDate: Date): Date[] => {
   const days: Date[] = [];
   let day = startDate;
 
-  for (let i = 0; i < 42; i++) {
+  for (let i = 0; i < TOTAL_CALENDAR_DAYS; i++) {
     days.push(day);
     day = addDays(day, 1);
   }

--- a/src/features/mypage/reservation-status/utils/calendarUtils.ts
+++ b/src/features/mypage/reservation-status/utils/calendarUtils.ts
@@ -75,17 +75,16 @@ export const canNavigateToNextMonth = (currentMonth: Date, maxDate: Date): boole
  * 현재 월의 달력에 표시할 모든 날짜 생성
  *
  * @description
- * 달력을 5행 7열(35개 셀)로 고정하여 표시
+ * 달력을 항상 6행 7열(42개 셀)로 고정하여 레이아웃 시프트 방지
  *
  * @param startDate - 캘린더에 표시될 시작 날짜
- * @returns 달력에 표시할 날짜 배열 (항상 35개)
+ * @returns 달력에 표시할 날짜 배열 (항상 42개)
  */
 export const generateCalendarDays = (startDate: Date): Date[] => {
   const days: Date[] = [];
   let day = startDate;
 
-  // 5주(35일)만 표시
-  for (let i = 0; i < 35; i++) {
+  for (let i = 0; i < 42; i++) {
     days.push(day);
     day = addDays(day, 1);
   }


### PR DESCRIPTION
## ✅ PR 체크리스트

### 1. 코드 & 기능

- [x] 변수/함수 이름 이해 가능한지
- [x] 기능 정상 동작 & 콘솔 에러 없음

## 2. UI

- [x] UI 동작 및 레이아웃 확인

## 3. 컨벤션

- [x] 팀 컨벤션에 맞게 함수 이름을 정의했는지

## 🔗 이슈 번호

- close #453

## ✨ 작업한 내용

**`calendarUtils.ts`**
- `generateCalendarDays` 35개(5행) 고정 → 42개(6행) 고정
- 1일이 목/금/토인 달(예: 2026년 5월)의 마지막 날이 6번째 행에 위치해 표시되지 않던 버그 수정
- 5행으로 충분한 달은 다음 달 날짜가 흐리게 채워져 레이아웃 일관성 유지

**`ReservationCalendarSkeleton.tsx`**
- 6행 기준 실제 높이에 맞춰 스켈레톤 높이 조정
  - mobile: `h-605` → `h-709`
  - sm/lg: `h-770` / `h-776` → `h-888`

## 💁 리뷰 요청 / 코멘트

## 💡 참고사항